### PR TITLE
Generate help tags

### DIFF
--- a/packman.lua
+++ b/packman.lua
@@ -248,7 +248,7 @@ local function get_dir_opt()
 end
 
 local function get_files_in_dir(dir)
-	return io.popen('/bin/ls -d ' .. dir .. '/*')
+	return io.popen('/bin/ls -d ' .. dir .. '/* 2>/dev/null')
 end
 
 local function get_git_url(dir)

--- a/packman.lua
+++ b/packman.lua
@@ -543,6 +543,24 @@ function packman.clear()
 	end
 end
 
+function packman.helptags(pattern)
+	local files = find_installed_files(pattern)
+
+	if #files == 0 then
+		notify:alert(string.format('Unable to find plugin %q', pattern))
+		return
+	end
+
+	for _, file in ipairs(files) do
+		local doc_dir = file .. '/doc'
+		local isdir = vim.api.nvim_call_function('isdirectory', {doc_dir})
+		if isdir == 1 then
+			print(file)
+			vim.cmd("helptags " .. doc_dir)
+		end
+	end
+end
+
 packman.init()
 
 return packman

--- a/packman.lua
+++ b/packman.lua
@@ -361,7 +361,7 @@ local function find_installed_files(pattern)
 	for _, files_found in ipairs({files_start, files_opt}) do
 		for fname in files_found:lines() do
 			local name = vim.api.nvim_call_function('fnamemodify', {fname, ':t'})
-			if pattern == name then
+			if pattern == name or pattern == nil then
 				table.insert(files, fname)
 			end
 		end


### PR DESCRIPTION
list of changes
- get_files_in_dir redirected stderr to /dev/null
neovim visually breaks when ls returns an error

- new function helptags generate help tags if a doc folder exist in the plugin directory

- find_installed_files if pattern is nil return all found plugins
to be able to update and generate helptags for all plugins with a single function call